### PR TITLE
Fix expand not working with single navigations

### DIFF
--- a/gitversion.yml
+++ b/gitversion.yml
@@ -3,3 +3,4 @@ branches: {}
 ignore:
   sha: []
 merge-message-formats: {}
+continuous-delivery-fallback-tag: ''

--- a/src/core/entity/expand/entity-accessor.ts
+++ b/src/core/entity/expand/entity-accessor.ts
@@ -1,5 +1,5 @@
 import { PrefixGenerator } from "../../../utils/prefix-generator";
-import { AnyArray, InferArrayType } from "../../../utils/types";
+import { AnyArray, SingleType } from "../../../utils/types";
 import { Value } from "../../../values/base";
 import { AllCollectionValue, AnyCollectionValue } from "../../../values/collection";
 import { EntityPropertyValue } from "../../../values/property";
@@ -18,13 +18,13 @@ export interface EntityAccessor<TEntity> {
    * @param property The name of the collection property.
    * @param builder The condition builder.
    */
-  all<TKey extends keyof TEntity & string>(property: TKey extends keyof TEntity ? (TEntity[TKey] extends AnyArray ? TKey : never) : never, builder: (entity: EntityAccessor<InferArrayType<TEntity[TKey]>>) => Value<boolean>): Value<boolean>;
+  all<TKey extends keyof TEntity & string>(property: TKey extends keyof TEntity ? (TEntity[TKey] extends AnyArray ? TKey : never) : never, builder: (entity: EntityAccessor<SingleType<TEntity[TKey]>>) => Value<boolean>): Value<boolean>;
   /**
    * Tests if any item in a collection on the entity matches a condition.
    * @param property The name of the collection property.
    * @param builder The condition builder.
    */
-  any<TKey extends keyof TEntity & string>(property: TKey extends keyof TEntity ? (TEntity[TKey] extends AnyArray ? TKey : never) : never, builder: (entity: EntityAccessor<InferArrayType<TEntity[TKey]>>) => Value<boolean>): Value<boolean>;
+  any<TKey extends keyof TEntity & string>(property: TKey extends keyof TEntity ? (TEntity[TKey] extends AnyArray ? TKey : never) : never, builder: (entity: EntityAccessor<SingleType<TEntity[TKey]>>) => Value<boolean>): Value<boolean>;
 }
 
 /**
@@ -46,19 +46,19 @@ export class EntityAccessorImpl<TEntity> {
     return new EntityPropertyValue<TEntity, TKey>(this.path, property);
   }
 
-  all<TKey extends keyof TEntity & string>(property: TKey extends keyof TEntity ? (TEntity[TKey] extends AnyArray ? TKey : never) : never, builder: (entity: EntityAccessor<InferArrayType<TEntity[TKey]>>) => Value<boolean>): Value < boolean > {
+  all<TKey extends keyof TEntity & string>(property: TKey extends keyof TEntity ? (TEntity[TKey] extends AnyArray ? TKey : never) : never, builder: (entity: EntityAccessor<SingleType<TEntity[TKey]>>) => Value<boolean>): Value < boolean > {
     const generator = this.generator;
     const path = generator.getPath();
-    const accessor = new EntityAccessorImpl<InferArrayType<TEntity[TKey]>>(generator, path);
+    const accessor = new EntityAccessorImpl<SingleType<TEntity[TKey]>>(generator, path);
 
     const value = builder(accessor);
     return new AllCollectionValue(property, path, value);
   }
 
-  any<TKey extends keyof TEntity & string>(property: TKey extends keyof TEntity ? (TEntity[TKey] extends AnyArray ? TKey : never) : never, builder: (entity: EntityAccessor<InferArrayType<TEntity[TKey]>>) => Value<boolean>): Value<boolean> {
+  any<TKey extends keyof TEntity & string>(property: TKey extends keyof TEntity ? (TEntity[TKey] extends AnyArray ? TKey : never) : never, builder: (entity: EntityAccessor<SingleType<TEntity[TKey]>>) => Value<boolean>): Value<boolean> {
     const generator = this.generator;
     const path = generator.getPath();
-    const accessor = new EntityAccessorImpl<InferArrayType<TEntity[TKey]>>(generator, path);
+    const accessor = new EntityAccessorImpl<SingleType<TEntity[TKey]>>(generator, path);
 
     const value = builder(accessor);
     return new AnyCollectionValue(property, path, value);

--- a/src/core/entity/expand/entity-expand.ts
+++ b/src/core/entity/expand/entity-expand.ts
@@ -1,5 +1,5 @@
 import { PrefixGenerator } from "../../../utils/prefix-generator";
-import { InferArrayType, SafeAny } from "../../../utils/types";
+import { SafeAny, SingleType } from "../../../utils/types";
 import { Value } from "../../../values/base";
 import { Count } from "../../parameters/count";
 import { Expand, expandToString } from "../../parameters/expand";
@@ -26,7 +26,7 @@ export interface EntityExpand<TEntity> {
    */
   expand<TExpanded extends keyof TEntity & string, TNewExpanded>(
     property: TExpanded /*& (TEntity[TExpanded] extends Array<any> | object ? TExpanded : never)*/,
-    builder?: (expand: EntityExpand<InferArrayType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntityExpand<TEntity>;
+    builder?: (expand: EntityExpand<SingleType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntityExpand<TEntity>;
   /**
    * Filters the returned entities to the ones matching the provided condition.
    * @param builder The filter builder.
@@ -110,8 +110,8 @@ export class EntityExpandImpl<TEntity> implements EntityExpand<TEntity>, Ordered
     return new EntityExpandImpl<TEntity>(this.property, options);
   }
 
-  expand<TExpanded extends keyof TEntity & string, TNewExpanded>(property: TExpanded, builder?: (expand: EntityExpand<InferArrayType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntityExpand<TEntity> {
-    let expander: SafeAny = new EntityExpandImpl<InferArrayType<TEntity[TExpanded]>>(property);
+  expand<TExpanded extends keyof TEntity & string, TNewExpanded>(property: TExpanded, builder?: (expand: EntityExpand<SingleType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntityExpand<TEntity> {
+    let expander: SafeAny = new EntityExpandImpl<SingleType<TEntity[TExpanded]>>(property);
     if (builder) {
       expander = builder(expander);
     }

--- a/src/core/entity/set/entity-set.ts
+++ b/src/core/entity/set/entity-set.ts
@@ -1,5 +1,5 @@
 import { PrefixGenerator } from "../../../utils/prefix-generator";
-import { InferArrayType, SafeAny } from "../../../utils/types";
+import { SafeAny, SingleType } from "../../../utils/types";
 import { Value } from "../../../values/base";
 import { Count } from "../../parameters/count";
 import { Expand } from "../../parameters/expand";
@@ -33,7 +33,7 @@ export interface EntitySet<TEntity> {
    */
   expand<TExpanded extends keyof TEntity & string, TNewExpanded>(
     property: TExpanded /*& (TEntity[TExpanded] extends Array<any> | object ? TExpanded : never)*/,
-    builder?: (expand: EntityExpand<InferArrayType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntitySet<TEntity>;
+    builder?: (expand: EntityExpand<SingleType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntitySet<TEntity>;
   /**
    * Filters the returned entities to the ones matching the provided condition.
    * @param builder The filter builder.
@@ -121,8 +121,8 @@ export class EntitySetImpl<TEntity> implements EntitySet<TEntity>, OrderedEntity
     return this.new<TEntity>(this.worker, options);
   }
 
-  expand<TExpanded extends keyof TEntity & string, TNewExpanded>(property: TExpanded, builder?: (expand: EntityExpand<InferArrayType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntitySet<TEntity> {
-    let expander: SafeAny = new EntityExpandImpl<InferArrayType<TEntity[TExpanded]>>(property);
+  expand<TExpanded extends keyof TEntity & string, TNewExpanded>(property: TExpanded, builder?: (expand: EntityExpand<SingleType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntitySet<TEntity> {
+    let expander: SafeAny = new EntityExpandImpl<SingleType<TEntity[TExpanded]>>(property);
     if (builder) {
       expander = builder(expander);
     }

--- a/src/core/entity/single/entity-single.ts
+++ b/src/core/entity/single/entity-single.ts
@@ -1,4 +1,4 @@
-import { InferArrayType, SafeAny } from "../../../utils/types";
+import { SafeAny, SingleType } from "../../../utils/types";
 import { Expand } from "../../parameters/expand";
 import { ODataOptions } from "../../parameters/odata-options";
 import { Select } from "../../parameters/select";
@@ -22,7 +22,7 @@ export interface EntitySingle<TEntity> {
    */
   expand<TExpanded extends keyof TEntity & string, TNewExpanded>(
     property: TExpanded /*& (TEntity[TExpanded] extends Array<any> | object ? TExpanded : never)*/,
-    builder?: (expand: EntityExpand<InferArrayType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntitySingle<TEntity>;
+    builder?: (expand: EntityExpand<SingleType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntitySingle<TEntity>;
   /**
    * Selects a subset of properties to be returned on the entity or entities.
    * @param properties The properties to be returned.
@@ -60,8 +60,8 @@ export class EntitySingleImpl<TEntity> implements EntitySingle<TEntity> {
     return new EntitySingleImpl(this.worker as unknown as EntitySingleWorkerImpl<TNewEntity>, options);
   }
 
-  expand<TExpanded extends keyof TEntity & string, TNewExpanded>(property: TExpanded, builder?: (expand: EntityExpand<InferArrayType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntitySingle<TEntity> {
-    let expander: SafeAny = new EntityExpandImpl<InferArrayType<TEntity[TExpanded]>>(property);
+  expand<TExpanded extends keyof TEntity & string, TNewExpanded>(property: TExpanded, builder?: (expand: EntityExpand<SingleType<TEntity[TExpanded]>>) => EntityExpand<TNewExpanded>): EntitySingle<TEntity> {
+    let expander: SafeAny = new EntityExpandImpl<SingleType<TEntity[TExpanded]>>(property);
     if (builder) {
       expander = builder(expander);
     }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -6,7 +6,7 @@ export type AnyArray = Array<SafeAny>;
 /**
  * Extracts the type from an array, otherwise returns the initial type.
  */
-export type InferArrayType<TValue> = TValue extends (infer UValue)[] ? UValue : never;
+export type SingleType<TValue> = TValue extends (infer UValue)[] ? UValue : TValue;
 
 /**
  * Returns the initial type, only if it is an object or array.


### PR DESCRIPTION
Fixes #8 by addressing a type issue. Now, the type that was used to extract the array type defaults to the initial type for non-arrays. While expand previously worked with collection navigations, it will now work with single navigations.