### PR TITLE
Add special handling for a top value of zero

### DIFF
--- a/src/core/parameters/odata-options.ts
+++ b/src/core/parameters/odata-options.ts
@@ -79,7 +79,7 @@ export function getParams(options: ODataOptions): QueryParams {
     params["$skip"] = skipToString(options.skip);
   }
 
-  if (options.top) {
+  if (options.top !== undefined) {
     params["$top"] = topToString(options.top);
   }
 

--- a/tests/core/entity/set/entity-set.spec.ts
+++ b/tests/core/entity/set/entity-set.spec.ts
@@ -369,6 +369,13 @@ describe('EntitySetImpl', () => {
     expect(params['$top']).toBe("20");
   });
 
+  it('should top with 0', () => {
+    const topped = set.top(0);
+
+    const params = getParams(topped.getOptions());
+    expect(params['$top']).toBe("0");
+  });
+
   it('should process multiple options simultaneously', () => {
     const result = set
       .filter(e =>


### PR DESCRIPTION
Fixes #9 by altering the "top" option, excluding it only if the value is undefined. The value was previously excluded when falsy, preventing top(0) from functioning as expected.