### PR TITLE
Fix expanding a nullish entity creating a "never" property selector

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,9 +4,9 @@
 export type AnyArray = Array<SafeAny>;
 
 /**
- * Extracts the type from an array, otherwise returns the initial type.
+ * Extracts the type from an array, otherwise returns the initial type. Also strips out null and undefined in the case of union types.
  */
-export type SingleType<TValue> = TValue extends (infer UValue)[] ? UValue : TValue;
+export type SingleType<TValue> = Exclude<TValue extends (infer UValue)[] ? UValue : TValue, null | undefined>;
 
 /**
  * Returns the initial type, only if it is an object or array.


### PR DESCRIPTION
Fixes #14, an issue in the typing of `EntityExpand`, which caused it to return methods typed to `never` when the expanded property could be `null` or `undefined`.